### PR TITLE
Changes to ChatDashboard to separate open and closed convos

### DIFF
--- a/use-my-tools/src/components/AccountPage.js
+++ b/use-my-tools/src/components/AccountPage.js
@@ -107,7 +107,6 @@ class AccountPage extends Component {
         });
     };
     
-    
     imageUpload = event => {
         console.log('inside imageUpload file is', this.state.selectedFile);
     
@@ -200,7 +199,7 @@ class AccountPage extends Component {
                     
                         <img
                             src={this.state.imageUrl}
-                            alt="profile picture"
+                            alt="avatar"
                         />
                         
                     

--- a/use-my-tools/src/components/Chat/ChatDashboard.js
+++ b/use-my-tools/src/components/Chat/ChatDashboard.js
@@ -86,33 +86,37 @@ class ChatDashboard extends React.Component {
         const convoSelected = this.state.convoSelected;
         return (
             <div>
-            
-            <div className="chat-dashboard-container">
-                <div className="chat-dash-left-container">
-                    
-                    <ConvoList
-                        uid={this.state.uid}
-                        currentConvoId={this.state.currentConvoId}
-                        currentConvoClosed={this.state.currentConvoClosed}
-                        handleOpenConvoSelect={this.handleOpenConvoSelect}
-                        handleClosedConvoSelect={this.handleClosedConvoSelect}
-                    />
-                </div>
-
-                <div className="chat-dash-right-container">
-                    {!convoSelected ? (
-                        <p>No conversation selected.</p>
-                        ) : (
-                            <ChatView
+                {this.state.uid ? (
+                    <div className="chat-dashboard-container">
+                        <div className="chat-dash-left-container">
+                            
+                            <ConvoList
                                 uid={this.state.uid}
-                                currentConvo={this.state.currentConvo}
-                                closeConvo={this.closeConvo}
+                                currentConvoId={this.state.currentConvoId}
                                 currentConvoClosed={this.state.currentConvoClosed}
+                                handleOpenConvoSelect={this.handleOpenConvoSelect}
+                                handleClosedConvoSelect={this.handleClosedConvoSelect}
                             />
-                        )
-                    }
-                </div>
-            </div>
+                        </div>
+
+                        <div className="chat-dash-right-container">
+                            {!convoSelected ? (
+                                <p>No conversation selected.</p>
+                                ) : (
+                                    <ChatView
+                                        uid={this.state.uid}
+                                        currentConvo={this.state.currentConvo}
+                                        closeConvo={this.closeConvo}
+                                        currentConvoClosed={this.state.currentConvoClosed}
+                                    />
+                                )
+                            }
+                        </div>  
+                    </div>
+                ) : ( 
+                    ''
+                )}
+                
             </div>
         );
     }

--- a/use-my-tools/src/components/Chat/ChatDashboard.js
+++ b/use-my-tools/src/components/Chat/ChatDashboard.js
@@ -91,6 +91,7 @@ class ChatDashboard extends React.Component {
                 <div className="chat-dash-left-container">
                     
                     <ConvoList
+                        uid={this.state.uid}
                         currentConvoId={this.state.currentConvoId}
                         currentConvoClosed={this.state.currentConvoClosed}
                         handleOpenConvoSelect={this.handleOpenConvoSelect}

--- a/use-my-tools/src/components/Chat/ChatView.js
+++ b/use-my-tools/src/components/Chat/ChatView.js
@@ -5,15 +5,15 @@ import { withRouter} from "react-router-dom"
 import Typography from '@material-ui/core/Typography';
 // import AppBar from 'material-ui/AppBar';
 import RaisedButton from 'material-ui/RaisedButton';
-import Paper from '@material-ui/core/Paper';
-import Avatar from '@material-ui/core/Avatar';
+// import Paper from '@material-ui/core/Paper';
+// import Avatar from '@material-ui/core/Avatar';
 // import ButtonBase from '@material-ui/core/ButtonBase';
 // import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 
 import './ChatView.css';
 // import { ThemeProvider, MessageList, MessageGroup, MessageText, MessageTitle, Message, AgentBar, Row, IconButton, SendIcon, CloseIcon, TextComposer, AddIcon, TextInput, SendButton, EmojiIcon } from '@livechat/ui-kit';
-import { Grid } from '@material-ui/core';
+// import { Grid } from '@material-ui/core';
 
 import { withFirebase } from "../Firebase";
 
@@ -175,7 +175,7 @@ class ChatViewBase extends Component {
     // The first query snapshot contains 'added' events 
     // for all existing documents that match the query
     let messages = [];
-    let messagesQuery = this.props.firebase.db
+    this.props.firebase.db
       .collection('conversations')
       .doc(compoundUID)
       .collection('messages')

--- a/use-my-tools/src/components/Chat/ChatView.js
+++ b/use-my-tools/src/components/Chat/ChatView.js
@@ -269,7 +269,7 @@ class ChatViewBase extends Component {
                           alignClass = 'message-container align-left'
                         }
                         return (
-                          <MuiThemeProvider>
+                          // <MuiThemeProvider>
                           <div className={alignClass} key={index}>
                             <div className="message-header">
                               {/* <Avatar alt="Avatar" className={classes.avatar}>
@@ -302,7 +302,7 @@ class ChatViewBase extends Component {
                             </div>
 
                           </div>
-                          </MuiThemeProvider>
+                          // </MuiThemeProvider>
                         );
                     })}
               </div>
@@ -337,6 +337,7 @@ class ChatViewBase extends Component {
                       marginLeft: '3px',
                     }}>
                       <MuiThemeProvider>
+                        <div>
                         <RaisedButton
                           label="Send"
                           primary={true}
@@ -346,6 +347,7 @@ class ChatViewBase extends Component {
                           label="End Convo"
                           onClick={this.handleCloseConvo}
                         />
+                        </div>
                       </MuiThemeProvider>
                     </div>
                   </form>

--- a/use-my-tools/src/components/Chat/ChatView.js
+++ b/use-my-tools/src/components/Chat/ChatView.js
@@ -318,7 +318,7 @@ class ChatViewBase extends Component {
                   </div>       */}
                   <form className={classes.inputForm} onSubmit={this.onSubmit}>
                     <input
-                      hintText="message"
+                      // hintText="message"
                       name="message"
                       type="text"
                       value={this.state.message}

--- a/use-my-tools/src/components/Chat/ConvoList/ConvoList.js
+++ b/use-my-tools/src/components/Chat/ConvoList/ConvoList.js
@@ -10,6 +10,8 @@ import Tab from "@material-ui/core/Tab";
 // import NoSsr from "@material-ui/core/NoSsr";
 // import Typography from "@material-ui/core/Typography";
 
+import { withFirebase } from "../../Firebase";
+
 import Convos from './Convos';
 
 
@@ -67,43 +69,30 @@ const styles = {
   }
 };
 
-class ConvoList extends React.Component {
+class ConvoListBase extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
           value: 0,  // value corresponding to Open tab to display the Open convo list on mount
-          newConvosCount: 0
+          newConvosCount: 0,
+          openConvos: [],
+          closedConvos: []
         };
         // this.intervalID = 0;
     }
 
-    
-
     componentDidMount() {
-      // this.intervalID = setInterval(this.getNewConvos, 5000);
+
+
+
     }
 
-    componentWillUnmount() {
-      // clearInterval(this.intervalID);
-    }
 
     // getNewConvos is used by Convolist to check how many New Convos are in the database
     // in order to update the number icon on the New tab showing how many are in that list
     // even when another tab/list is selected:
 
-    // getNewConvos= () => {
-    //   axios.get(`/api/chat/queue`)
-    //   .then(response => {
-    //     // if (response.data.length > this.state.newConvos.length) {
-    //       this.setState({
-    //         newConvosCount: response.data.length
-    //       }, () => console.log('newConvosLength: ', this.state.newConvosLength));
-    //     // }
-    //   })
-    //   .catch(error => {
-    //     console.log(error.message);
-    //   })
-    // }
+    
 
     handleTabSelect= (event, value) => {
       this.setState({ value });
@@ -189,4 +178,7 @@ ConvoList.propTypes = {
     classes: PropTypes.object.isRequired
 };
 
-export default withStyles(styles)(ConvoList);
+ 
+const ConvoList = withStyles(styles)(withFirebase(ConvoListBase));
+
+export default ConvoList;

--- a/use-my-tools/src/components/Chat/ConvoList/ConvoList.js
+++ b/use-my-tools/src/components/Chat/ConvoList/ConvoList.js
@@ -163,6 +163,7 @@ class ConvoList extends React.Component {
           <div className={classes.queueList}>
                 {this.state.value === 0 && 
                   <Convos  
+                    uid={this.props.uid}
                     isOpen={true} 
                     currentConvoId={this.props.currentConvoId} 
                     handleConvoSelect={this.props.handleOpenConvoSelect} 
@@ -170,6 +171,7 @@ class ConvoList extends React.Component {
                 }
                 {this.state.value === 1 && 
                   <Convos 
+                    uid={this.props.uid}
                     isOpen={false} 
                     currentConvoId={this.props.currentConvoId} 
                     currentConvoClosed={this.props.currentConvoClosed} 

--- a/use-my-tools/src/components/Chat/ConvoList/ConvoList.js
+++ b/use-my-tools/src/components/Chat/ConvoList/ConvoList.js
@@ -170,16 +170,18 @@ class ConvoListBase extends React.Component {
           <div className={classes.queueList}>
                 {this.state.value === 0 && 
                   <Convos  
+                    convos={this.state.openConvos}
                     uid={this.props.uid}
-                    isOpen={true} 
+                    // isOpen={true} 
                     currentConvoId={this.props.currentConvoId} 
                     handleConvoSelect={this.props.handleOpenConvoSelect} 
                   />
                 }
                 {this.state.value === 1 && 
                   <Convos 
+                    convos={this.state.closedConvos}
                     uid={this.props.uid}
-                    isOpen={false} 
+                    // isOpen={false} 
                     currentConvoId={this.props.currentConvoId} 
                     currentConvoClosed={this.props.currentConvoClosed} 
                     handleConvoSelect={this.props.handleClosedConvoSelect} 

--- a/use-my-tools/src/components/Chat/ConvoList/ConvoList.js
+++ b/use-my-tools/src/components/Chat/ConvoList/ConvoList.js
@@ -82,7 +82,32 @@ class ConvoListBase extends React.Component {
     }
 
     componentDidMount() {
-
+      const uid = this.props.uid;
+      console.log(uid);
+      let openConvos = [];
+      let closedConvos = [];
+      let convos = [];
+      // one-time get of convos all convos (open and closed) where UIDs contains current user uid:
+      this.props.firebase.db
+        .collection('conversations')
+        .where('UIDs', 'array-contains', `${uid}`)
+        .get()
+        .then(snapshot => {
+          if (snapshot.empty) {
+            console.log('No matching documents.');
+            return;
+          }  
+      
+          snapshot.forEach(doc => {
+            convos.push(doc.data());
+            // console.log(doc.id, '=>', doc.data());
+          });
+          console.log(convos);
+          this.setState({ convos });
+        })
+        .catch(err => {
+          console.log('Error getting documents', err);
+        });
 
 
     }
@@ -98,20 +123,6 @@ class ConvoListBase extends React.Component {
       this.setState({ value });
     };
 
-    // handleQueueConvoSelect = (convo_id, customer_uid, customer_name, summary) => {
-    //   // Remove convo from the Queue by updating in_q to false in the convo's db entry
-    //   const data = { id: convo_id };
-    //   const deQueueRequest = axios.put('/api/chat/dequeue', data);
-    //   deQueueRequest
-    //       .then(response => {
-    //           console.log("Conversation removed from Queue.");
-    //           this.props.handleQueueConvoSelect(convo_id, customer_uid, customer_name, summary);  // call hander at ChatDashboard to pass current convo info to ChatView
-    //           this.setState({ value: 1 });                                                        // switch selected tab to Open tab
-    //       })
-    //       .catch(error => {
-    //           console.log(error.message);
-    //       })
-    // }
 
     render() {
       const { classes } = this.props;
@@ -174,7 +185,7 @@ class ConvoListBase extends React.Component {
     }
 }
 
-ConvoList.propTypes = {
+ConvoListBase.propTypes = {
     classes: PropTypes.object.isRequired
 };
 

--- a/use-my-tools/src/components/Chat/ConvoList/ConvoList.js
+++ b/use-my-tools/src/components/Chat/ConvoList/ConvoList.js
@@ -75,6 +75,7 @@ class ConvoListBase extends React.Component {
         this.state = {
           value: 0,  // value corresponding to Open tab to display the Open convo list on mount
           newConvosCount: 0,
+          convos: [],
           openConvos: [],
           closedConvos: []
         };
@@ -87,7 +88,7 @@ class ConvoListBase extends React.Component {
       let openConvos = [];
       let closedConvos = [];
       let convos = [];
-      // one-time get of convos all convos (open and closed) where UIDs contains current user uid:
+      // one-time get of convos (open and closed) where UIDs array contains current user uid:
       this.props.firebase.db
         .collection('conversations')
         .where('UIDs', 'array-contains', `${uid}`)
@@ -99,11 +100,17 @@ class ConvoListBase extends React.Component {
           }  
       
           snapshot.forEach(doc => {
-            convos.push(doc.data());
+            if (doc.data().isOpen === true) {
+              openConvos.push(doc.data());
+            } else {
+              closedConvos.push(doc.data());
+            }
+              
             // console.log(doc.id, '=>', doc.data());
           });
-          console.log(convos);
-          this.setState({ convos });
+          console.log('openConvos: ', openConvos);
+          console.log('closedConvos: ', closedConvos);
+          this.setState({ openConvos, closedConvos });
         })
         .catch(err => {
           console.log('Error getting documents', err);

--- a/use-my-tools/src/components/Chat/ConvoList/Convos.js
+++ b/use-my-tools/src/components/Chat/ConvoList/Convos.js
@@ -63,9 +63,9 @@ const styles = theme => ({
 });
 
 const ConvosBase = props => {
-  
     
   const { classes } = props;
+  
   return (
     <div className={classes.root}>
       <Typography
@@ -74,7 +74,12 @@ const ConvosBase = props => {
       </Typography>
       <div className={classes.convoList}>
           {props.convos.map((convo, index) => {
-
+            let recipientUID = null;
+            if (convo.UIDs[0] === props.uid) {
+              recipientUID = convo.UIDs[1];
+            } else {
+              recipientUID = convo.UIDs[0];
+            }
             return (
               <div className={classes.queueItem} key={index}>
                 <MuiThemeProvider>
@@ -84,7 +89,7 @@ const ConvosBase = props => {
                     // onClick={() => this.props.handleConvoSelect(convo.compoundUID)}
                     onClick={() => props.handleConvoSelect(convo)}
                   >
-                    <p>{convo.compoundUID}</p>
+                    <p>{convo[recipientUID]}</p>
                   </Paper>
                 </MuiThemeProvider>
               </div>

--- a/use-my-tools/src/components/Chat/ConvoList/Convos.js
+++ b/use-my-tools/src/components/Chat/ConvoList/Convos.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-// import io from 'socket.io-client';
 // import { withRouter} from "react-router-dom"
 // import { BrowserRouter as Router, Link, Route, Redirect } from 'react-router-dom'
 // import axios from 'axios';
@@ -12,7 +11,7 @@ import { withStyles } from '@material-ui/core/styles';
 // import { ThemeProvider, MessageList, MessageGroup, MessageText, MessageTitle, Message, AgentBar, Row } from '@livechat/ui-kit';
 
 import { withFirebase } from "../../Firebase";
-// import { FirebaseContext } from '../../Firebase';
+
 
 const styles = theme => ({
   root: {
@@ -62,14 +61,6 @@ const styles = theme => ({
     fontSize: '20px',
   }
 });
-
-// const ConvosBox = () => (
-//   <div>
-//     <FirebaseContext.Consumer>
-//       {firebase => <Convos firebase={firebase} />}
-//     </FirebaseContext.Consumer>
-//   </div>
-// );
 
 class ConvosBase extends Component {
   constructor(props) {
@@ -124,7 +115,7 @@ class ConvosBase extends Component {
           conversations.push(doc.data());
           // console.log(doc.id, '=>', doc.data());
         });
-        console.log(conversations);
+        console.log('conversations after first query: ', conversations);
       })
       .catch(err => {
         console.log('Error getting documents', err);
@@ -144,7 +135,7 @@ class ConvosBase extends Component {
           conversations.push(doc.data());
           // console.log(doc.id, '=>', doc.data());
         });
-        console.log(conversations);
+        console.log('conversations after second query: ', conversations);
         this.setState({ conversations });
       })
       .catch(err => {

--- a/use-my-tools/src/components/Chat/ConvoList/Convos.js
+++ b/use-my-tools/src/components/Chat/ConvoList/Convos.js
@@ -112,7 +112,7 @@ class ConvosBase extends Component {
           // return;
         }  
         snapshot.forEach(doc => {
-          conversations.push(doc.data());
+          conversations.push(doc.data()); // push each doc from the conversations collection
           // console.log(doc.id, '=>', doc.data());
         });
         console.log('conversations after first query: ', conversations);

--- a/use-my-tools/src/components/Chat/ConvoList/Convos.js
+++ b/use-my-tools/src/components/Chat/ConvoList/Convos.js
@@ -74,11 +74,11 @@ class ConvosBase extends Component {
   componentDidMount() {
     // this.getConvos();
     const uid = this.props.uid;
-    console.log('convos this.props: ', this.props);
+    // console.log('convos this.props: ', this.props);
     const isOpen = this.props.isOpen;
     
     let conversations = [];
-    // one-time get of open convos:
+    // one-time get of convos:
     // this.props.firebase.db
     //   .collection('conversations')
     //   .where('isOpen', '==', isOpen)  //isOpen can be true or false depending on prop
@@ -101,26 +101,26 @@ class ConvosBase extends Component {
     //   });
 
 
-    this.props.firebase.db
-      .collection('conversations')
-      .where('isOpen', '==', isOpen)  //  isOpen can be true or false depending on prop
-      .where('UIDs', 'array-contains', uid)
-      .get()
-      .then(snapshot => {
-        if (snapshot.empty) {
-          console.log('No matching documents.');
-          // return;
-        }  
-        snapshot.forEach(doc => {
-          conversations.push(doc.data()); // push each doc from the conversations collection
-          // console.log(doc.id, '=>', doc.data());
-        });
-        console.log('conversations: ', conversations);
-        this.setState({ conversations });
-      })
-      .catch(err => {
-        console.log('Error getting documents', err.message);
-      });
+    // this.props.firebase.db
+    //   .collection('conversations')
+    //   .where('UIDs', 'array-contains', uid)
+    //   .where('isOpen', '==', isOpen)  //  isOpen can be true or false depending on prop
+    //   .get()
+    //   .then(snapshot => {
+    //     if (snapshot.empty) {
+    //       console.log('No matching documents.');
+    //       // return;
+    //     }  
+    //     snapshot.forEach(doc => {
+    //       conversations.push(doc.data()); // push each doc from the conversations collection
+    //       // console.log(doc.id, '=>', doc.data());
+    //     });
+    //     console.log('conversations: ', conversations);
+    //     this.setState({ conversations });
+    //   })
+    //   .catch(err => {
+    //     console.log('Error getting documents', err.message);
+    //   });
 
 
   }

--- a/use-my-tools/src/components/Chat/ConvoList/Convos.js
+++ b/use-my-tools/src/components/Chat/ConvoList/Convos.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 // import io from 'socket.io-client';
 // import { withRouter} from "react-router-dom"
 // import { BrowserRouter as Router, Link, Route, Redirect } from 'react-router-dom'
-import axios from 'axios';
+// import axios from 'axios';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import Typography from '@material-ui/core/Typography';
 // import Grid from '@material-ui/core/Grid';
@@ -82,21 +82,64 @@ class ConvosBase extends Component {
 
   componentDidMount() {
     // this.getConvos();
+    const uid = this.props.uid;
     console.log('convos this.props: ', this.props);
     const isOpen = this.props.isOpen;
     
     let conversations = [];
     // one-time get of open convos:
+    // this.props.firebase.db
+    //   .collection('conversations')
+    //   .where('isOpen', '==', isOpen)  //isOpen can be true or false depending on prop
+    //   .get()
+    //   .then(snapshot => {
+    //     if (snapshot.empty) {
+    //       console.log('No matching documents.');
+    //       return;
+    //     }  
+    
+    //     snapshot.forEach(doc => {
+    //       conversations.push(doc.data());
+    //       // console.log(doc.id, '=>', doc.data());
+    //     });
+    //     console.log(conversations);
+    //     this.setState({ conversations });
+    //   })
+    //   .catch(err => {
+    //     console.log('Error getting documents', err);
+    //   });
+
+
     this.props.firebase.db
       .collection('conversations')
-      .where('isOpen', '==', isOpen)
+      .where('isOpen', '==', isOpen)  //isOpen can be true or false depending on prop
+      .where('UIDOne', '==', uid)
       .get()
       .then(snapshot => {
         if (snapshot.empty) {
           console.log('No matching documents.');
-          return;
+          // return;
         }  
-    
+        snapshot.forEach(doc => {
+          conversations.push(doc.data());
+          // console.log(doc.id, '=>', doc.data());
+        });
+        console.log(conversations);
+      })
+      .catch(err => {
+        console.log('Error getting documents', err);
+      });
+
+    this.props.firebase.db
+      .collection('conversations')
+      .where('isOpen', '==', isOpen)  //isOpen can be true or false depending on prop
+      .where('UIDTwo', '==', uid)
+      .get()
+      .then(snapshot => {
+        if (snapshot.empty) {
+          console.log('No matching documents.');
+          // return;
+        }  
         snapshot.forEach(doc => {
           conversations.push(doc.data());
           // console.log(doc.id, '=>', doc.data());
@@ -107,30 +150,8 @@ class ConvosBase extends Component {
       .catch(err => {
         console.log('Error getting documents', err);
       });
-    
-    // get single from convos list:
-    // let conversationsRef = this.props.firebase.db
-    //   .collection('conversations')
-    //   .where('isOpen', '==', true);
-    // let convo = conversationsRef
-    //   .where('compoundUID', '==', 'aabb')
-    //   .get();
-    // console.log(convo);
-      
-    // initialize listener to convos:
-    // this.props.firebase.users().on('value', snapshot => {
-    //   const usersObject = snapshot.val();
 
-    //   const usersList = Object.keys(usersObject).map(key => ({
-    //     ...usersObject[key],
-    //     uid: key,
-    //   }));
 
-    //   this.setState({
-    //     users: usersList,
-    //     loading: false,
-    //   });
-    // });
   }
 
   // getConvos = () => {

--- a/use-my-tools/src/components/Chat/ConvoList/Convos.js
+++ b/use-my-tools/src/components/Chat/ConvoList/Convos.js
@@ -62,68 +62,110 @@ const styles = theme => ({
   }
 });
 
-class ConvosBase extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      conversations: []
-    }
+const ConvosBase = props => {
+  
     
-  }
+  const { classes } = props;
+  return (
+    <div className={classes.root}>
+      <Typography
+        variant='h4'
+      >
+      </Typography>
+      <div className={classes.convoList}>
+          {props.convos.map((convo, index) => {
 
-  componentDidMount() {
-    // this.getConvos();
-    const uid = this.props.uid;
-    // console.log('convos this.props: ', this.props);
-    const isOpen = this.props.isOpen;
+            return (
+              <div className={classes.queueItem} key={index}>
+                <MuiThemeProvider>
+                  <Paper
+                    className={classes.paper}
+                    style={{ backgroundColor: props.currentConvoId === convo.convo_id ? '#E7E7E7' : 'white' }}
+                    // onClick={() => this.props.handleConvoSelect(convo.compoundUID)}
+                    onClick={() => props.handleConvoSelect(convo)}
+                  >
+                    <p>{convo.compoundUID}</p>
+                  </Paper>
+                </MuiThemeProvider>
+              </div>
+            );
+          })}
+          <div className={classes.listFooter}>
+            <p>End of list</p>
+          </div>
+      </div>
+    </div>
+
+  );
     
-    let conversations = [];
-    // one-time get of convos:
-    // this.props.firebase.db
-    //   .collection('conversations')
-    //   .where('isOpen', '==', isOpen)  //isOpen can be true or false depending on prop
-    //   .get()
-    //   .then(snapshot => {
-    //     if (snapshot.empty) {
-    //       console.log('No matching documents.');
-    //       return;
-    //     }  
+}
+
+const Convos =  withStyles(styles)(withFirebase(ConvosBase));
+
+export default Convos;
+
+
+// constructor(props) {
+  //   super(props);
+  //   this.state = {
+  //     conversations: []
+  //   }
     
-    //     snapshot.forEach(doc => {
-    //       conversations.push(doc.data());
-    //       // console.log(doc.id, '=>', doc.data());
-    //     });
-    //     console.log(conversations);
-    //     this.setState({ conversations });
-    //   })
-    //   .catch(err => {
-    //     console.log('Error getting documents', err);
-    //   });
+  // }
+
+  // componentDidMount() {
+  //   // this.getConvos();
+  //   const uid = this.props.uid;
+  //   // console.log('convos this.props: ', this.props);
+  //   const isOpen = this.props.isOpen;
+    
+  //   let conversations = [];
+  //   // one-time get of convos:
+  //   // this.props.firebase.db
+  //   //   .collection('conversations')
+  //   //   .where('isOpen', '==', isOpen)  //isOpen can be true or false depending on prop
+  //   //   .get()
+  //   //   .then(snapshot => {
+  //   //     if (snapshot.empty) {
+  //   //       console.log('No matching documents.');
+  //   //       return;
+  //   //     }  
+    
+  //   //     snapshot.forEach(doc => {
+  //   //       conversations.push(doc.data());
+  //   //       // console.log(doc.id, '=>', doc.data());
+  //   //     });
+  //   //     console.log(conversations);
+  //   //     this.setState({ conversations });
+  //   //   })
+  //   //   .catch(err => {
+  //   //     console.log('Error getting documents', err);
+  //   //   });
 
 
-    // this.props.firebase.db
-    //   .collection('conversations')
-    //   .where('UIDs', 'array-contains', uid)
-    //   .where('isOpen', '==', isOpen)  //  isOpen can be true or false depending on prop
-    //   .get()
-    //   .then(snapshot => {
-    //     if (snapshot.empty) {
-    //       console.log('No matching documents.');
-    //       // return;
-    //     }  
-    //     snapshot.forEach(doc => {
-    //       conversations.push(doc.data()); // push each doc from the conversations collection
-    //       // console.log(doc.id, '=>', doc.data());
-    //     });
-    //     console.log('conversations: ', conversations);
-    //     this.setState({ conversations });
-    //   })
-    //   .catch(err => {
-    //     console.log('Error getting documents', err.message);
-    //   });
+  //   // this.props.firebase.db
+  //   //   .collection('conversations')
+  //   //   .where('UIDs', 'array-contains', uid)
+  //   //   .where('isOpen', '==', isOpen)  //  isOpen can be true or false depending on prop
+  //   //   .get()
+  //   //   .then(snapshot => {
+  //   //     if (snapshot.empty) {
+  //   //       console.log('No matching documents.');
+  //   //       // return;
+  //   //     }  
+  //   //     snapshot.forEach(doc => {
+  //   //       conversations.push(doc.data()); // push each doc from the conversations collection
+  //   //       // console.log(doc.id, '=>', doc.data());
+  //   //     });
+  //   //     console.log('conversations: ', conversations);
+  //   //     this.setState({ conversations });
+  //   //   })
+  //   //   .catch(err => {
+  //   //     console.log('Error getting documents', err.message);
+  //   //   });
 
 
-  }
+  // }
 
   // getConvos = () => {
   //   console.log('getConvos called');
@@ -146,52 +188,38 @@ class ConvosBase extends Component {
   //   }
   // }
 
-    render() {
-        const { classes } = this.props;
+  // render() {
+    //     const { classes } = this.props;
+        
+//     return (
+//       <div className={classes.root}>
+//         <Typography
+//           variant='h4'
+//         >
+//         </Typography>
+//         <div className={classes.convoList}>
+//             {this.state.conversations.map((convo, index) => {
 
-        return (
-          <div className={classes.root}>
-            <Typography
-              variant='h4'
-            >
-            </Typography>
-            <div className={classes.convoList}>
-                {this.state.conversations.map((convo, index) => {
+//               return (
+//                 <div className={classes.queueItem} key={index}>
+//                   <MuiThemeProvider>
+//                     <Paper
+//                       className={classes.paper}
+//                       style={{ backgroundColor: this.props.currentConvoId === convo.convo_id ? '#E7E7E7' : 'white' }}
+//                       // onClick={() => this.props.handleConvoSelect(convo.compoundUID)}
+//                       onClick={() => this.props.handleConvoSelect(convo)}
+//                     >
+//                       <p>{convo.compoundUID}</p>
+//                     </Paper>
+//                   </MuiThemeProvider>
+//                 </div>
+//               );
+//             })}
+//             <div className={classes.listFooter}>
+//               <p>End of list</p>
+//             </div>
+//         </div>
+//       </div>
 
-                  return (
-                    <div className={classes.queueItem} key={index}>
-                      <MuiThemeProvider>
-                        <Paper
-                          className={classes.paper}
-                          style={{ backgroundColor: this.props.currentConvoId === convo.convo_id ? '#E7E7E7' : 'white' }}
-                          // onClick={() => this.props.handleConvoSelect(convo.compoundUID)}
-                          onClick={() => this.props.handleConvoSelect(convo)}
-                        >
-                          <p>{convo.compoundUID}</p>
-                        </Paper>
-                      </MuiThemeProvider>
-                    </div>
-                  );
-                })}
-                <div className={classes.listFooter}>
-                  <p>End of list</p>
-                </div>
-            </div>
-          </div>
-
-        );
-    }
-}
-
-
-// const Convos =  withStyles(styles)(withFirebase(ConvosBase));
-
-// export default (ConvosBox);
-
-// export {Convos}
-
-const Convos =  withStyles(styles)(withFirebase(ConvosBase));
-
-export default Convos;
-
-
+//     );
+// // }

--- a/use-my-tools/src/components/Chat/ConvoList/Convos.js
+++ b/use-my-tools/src/components/Chat/ConvoList/Convos.js
@@ -103,8 +103,8 @@ class ConvosBase extends Component {
 
     this.props.firebase.db
       .collection('conversations')
-      .where('isOpen', '==', isOpen)  //isOpen can be true or false depending on prop
-      .where('UIDOne', '==', uid)
+      .where('isOpen', '==', isOpen)  //  isOpen can be true or false depending on prop
+      .where('UIDs', 'array-contains', uid)
       .get()
       .then(snapshot => {
         if (snapshot.empty) {
@@ -115,31 +115,11 @@ class ConvosBase extends Component {
           conversations.push(doc.data()); // push each doc from the conversations collection
           // console.log(doc.id, '=>', doc.data());
         });
-        console.log('conversations after first query: ', conversations);
-      })
-      .catch(err => {
-        console.log('Error getting documents', err);
-      });
-
-    this.props.firebase.db
-      .collection('conversations')
-      .where('isOpen', '==', isOpen)  //isOpen can be true or false depending on prop
-      .where('UIDTwo', '==', uid)
-      .get()
-      .then(snapshot => {
-        if (snapshot.empty) {
-          console.log('No matching documents.');
-          // return;
-        }  
-        snapshot.forEach(doc => {
-          conversations.push(doc.data());
-          // console.log(doc.id, '=>', doc.data());
-        });
-        console.log('conversations after second query: ', conversations);
+        console.log('conversations: ', conversations);
         this.setState({ conversations });
       })
       .catch(err => {
-        console.log('Error getting documents', err);
+        console.log('Error getting documents', err.message);
       });
 
 

--- a/use-my-tools/src/components/Firebase/firebase.js
+++ b/use-my-tools/src/components/Firebase/firebase.js
@@ -23,7 +23,7 @@ class Firebase {
     // Firebase APIs:
     this.auth = app.auth();	 
     this.db = app.firestore();
-    this.db.setLogLevel("debug");
+    
   }
 
   createUser = (email, password) => 

--- a/use-my-tools/src/components/Firebase/firebase.js
+++ b/use-my-tools/src/components/Firebase/firebase.js
@@ -23,7 +23,7 @@ class Firebase {
     // Firebase APIs:
     this.auth = app.auth();	 
     this.db = app.firestore();
-
+    this.db.setLogLevel("debug");
   }
 
   createUser = (email, password) => 

--- a/use-my-tools/src/components/ImageCarousel.js
+++ b/use-my-tools/src/components/ImageCarousel.js
@@ -66,7 +66,7 @@ class ImageCarousel extends React.Component {
                 ? toolImages[activeStep].url
                 : "https://openclipart.org/image/2400px/svg_to_png/298157/CrossedTools.png"
             }
-            alt="tool-image"
+            alt="tool"
           />
         </div>
         <MobileStepper

--- a/use-my-tools/src/components/LocationSearchInput.js
+++ b/use-my-tools/src/components/LocationSearchInput.js
@@ -77,9 +77,9 @@ class LocationSearchInput extends React.Component {
             <div className="autocomplete-dropdown-container">
               {loading && <div>Loading...</div>}
               {suggestions.map(suggestion => {
-                const className = suggestion.active
-                  ? 'suggestion-item--active'
-                  : 'suggestion-item';
+                // const className = suggestion.active
+                //   ? 'suggestion-item--active'
+                //   : 'suggestion-item';
                 // inline style for demonstration purpose
                 const style = suggestion.active
                   ? { backgroundColor: '#fafafa', cursor: 'pointer' }

--- a/use-my-tools/src/components/Owner/AddTool.js
+++ b/use-my-tools/src/components/Owner/AddTool.js
@@ -3,7 +3,7 @@ import { withRouter } from "react-router-dom"
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import RaisedButton from 'material-ui/RaisedButton';
 import TextField from 'material-ui/TextField';
-import Button from "@material-ui/core/Button";
+// import Button from "@material-ui/core/Button";
 // import { withStyles } from "@material-ui/core/styles";
 import './css/AddTool.css';
 

--- a/use-my-tools/src/components/Renter/ContactOwner.js
+++ b/use-my-tools/src/components/Renter/ContactOwner.js
@@ -13,6 +13,8 @@ import axios from 'axios';
 class ContactOwnerBase extends React.Component {
   state = {
     open: false,
+    renterName: '',
+    ownerName: '',
     message: '',
     error: null
   };
@@ -22,24 +24,32 @@ class ContactOwnerBase extends React.Component {
     const ownerUID = this.props.ownerUID;
     let renterName = null;
     let ownerName = null;
+
     axios.get(`/api/users/username/${renterUID}`)
       .then(renter => {
         renterName = renter.data.first_name + ' ' + renter.data.last_name;
-        console.log('renter name: ', renterName);
+        // console.log('renter name: ', renterName);
 
         axios.get(`/api/users/username/${ownerUID}`)
           .then(owner => {
             ownerName = owner.data.first_name + ' ' + owner.data.last_name;
-            console.log('owner name: ', ownerName);
+            this.setState({ 
+              open: true,
+              renterName,
+              ownerName
+            }, () => console.log(this.state));
+            // console.log('owner name: ', ownerName);
           })
           .catch(error => {
             console.log(error.message);
           })
+
       })
       .catch(error => {
         console.log(error.message);
       })
-    this.setState({ open: true });
+
+    
   };
 
   handleClose = () => {

--- a/use-my-tools/src/components/Renter/ContactOwner.js
+++ b/use-my-tools/src/components/Renter/ContactOwner.js
@@ -76,7 +76,9 @@ class ContactOwnerBase extends React.Component {
     let convoData = {
         // UIDOne: renterUID,
         // UIDTwo: ownerUID,
-        UIDs: [renterUID, ownerUID],
+        UIDs: [renterUID, ownerUID],      // store UIDs in array so that convos can be queried on the array containing a uid
+        [renterUID]: this.state.renterName, // store name as value with uid as key so that each name is tied to the correct uid
+        [ownerUID]: this.state.ownerName,   // store name as value with uid as key so that each name is tied to the correct uid
         compoundUID,
         isOpen: true,
     }
@@ -85,7 +87,7 @@ class ContactOwnerBase extends React.Component {
     this.props.firebase.db
         .collection('conversations')
         .doc(`${compoundUID}`)
-        .set(convoData, { merge: true });
+        .set(convoData, { merge: true }); // merge if there is existing doc with same id, i.e., convo already started between the two users
 
 
     // define message data for firestore:

--- a/use-my-tools/src/components/Renter/ContactOwner.js
+++ b/use-my-tools/src/components/Renter/ContactOwner.js
@@ -8,7 +8,7 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import TextField from '@material-ui/core/TextField';
 
 import { withFirebase } from "../Firebase";
-
+import axios from 'axios';
 
 class ContactOwnerBase extends React.Component {
   state = {
@@ -18,6 +18,27 @@ class ContactOwnerBase extends React.Component {
   };
 
   handleClickOpen = () => {
+    const renterUID = this.props.renterUID;  // get uid of current user b/c request is going to firebase and not through built-in server auth
+    const ownerUID = this.props.ownerUID;
+    let renterName = null;
+    let ownerName = null;
+    axios.get(`/api/users/username/${renterUID}`)
+      .then(renter => {
+        renterName = renter.data.first_name + ' ' + renter.data.last_name;
+        console.log('renter name: ', renterName);
+
+        axios.get(`/api/users/username/${ownerUID}`)
+          .then(owner => {
+            ownerName = owner.data.first_name + ' ' + owner.data.last_name;
+            console.log('owner name: ', ownerName);
+          })
+          .catch(error => {
+            console.log(error.message);
+          })
+      })
+      .catch(error => {
+        console.log(error.message);
+      })
     this.setState({ open: true });
   };
 
@@ -30,7 +51,7 @@ class ContactOwnerBase extends React.Component {
   };
 
   handleConfirm = event => {
-    const renterUID = this.props.renterUID;
+    const renterUID = this.props.renterUID;  // get uid of current user b/c request is going to firebase and not through built-in server auth
     const ownerUID = this.props.ownerUID;
     // create compoundUID from owner and renter uid
     let compoundUID = null;

--- a/use-my-tools/src/components/Renter/ContactOwner.js
+++ b/use-my-tools/src/components/Renter/ContactOwner.js
@@ -7,8 +7,6 @@ import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import TextField from '@material-ui/core/TextField';
 
-import axios from 'axios';
-
 import { withFirebase } from "../Firebase";
 
 

--- a/use-my-tools/src/components/Renter/ContactOwner.js
+++ b/use-my-tools/src/components/Renter/ContactOwner.js
@@ -43,8 +43,9 @@ class ContactOwnerBase extends React.Component {
 
     // define convo data for conversations collection:
     let convoData = {
-        UIDOne: renterUID,
-        UIDTwo: ownerUID,
+        // UIDOne: renterUID,
+        // UIDTwo: ownerUID,
+        UIDs: [renterUID, ownerUID],
         compoundUID,
         isOpen: true,
     }

--- a/use-my-tools/src/components/Renter/FindTools.js
+++ b/use-my-tools/src/components/Renter/FindTools.js
@@ -115,7 +115,7 @@ class FindTools extends Component {
                                     <Grid item xs={3} key={index}>
                                         <Card className={classes.card}>
                                             {/* <ImageCarousel toolImages={tool.images} /> */}
-                                            <img src={tool.images[0].url} alt="tool-image" />
+                                            <img src={tool.images[0].url} alt="tool" />
                                             <CardContent className={classes.cardContent}>
                                                 <Typography gutterBottom className={classes.cardTitle} >
                                                     {tool.brand}{' '}{tool.name}

--- a/use-my-tools/src/components/Renter/ToolViewRenter.js
+++ b/use-my-tools/src/components/Renter/ToolViewRenter.js
@@ -51,7 +51,7 @@ class ToolViewRenter extends React.Component {
 
     render() {
         const { tool } = this.state;
-        const { classes } = this.props;
+        // const { classes } = this.props;
 
         return (
             <div className="pageContainer">


### PR DESCRIPTION
- Moved firestore convos get request to ConvoList component, which gets all convos for current user
- ConvoList separates convos into closedConvos and openConvos and passes openConvos as props to Convos when Open tab is selected, and passed closedConvos to Convos as prop when Closed tab is selected
- Refactored Convos component into functional component to utilize only props and no state
- Convos displays recipient name on convo list item instead of compound uid